### PR TITLE
Fix bug with lazy='dynamic'

### DIFF
--- a/dictalchemy/utils.py
+++ b/dictalchemy/utils.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import, division
 from sqlalchemy.orm import (RelationshipProperty, ColumnProperty,
                             SynonymProperty)
 from sqlalchemy.orm.collections import InstrumentedList, MappedCollection
+from sqlalchemy.orm.dynamic import AppenderMixin
+from sqlalchemy.orm.query import Query
 
 from dictalchemy import constants
 from dictalchemy import errors
@@ -144,6 +146,14 @@ def asdict(model, exclude=None, exclude_underscore=None, exclude_pk=None,
                     children[child_key] = child.asdict(**args)
                 else:
                     children[child_key] = child.dict(child)
+            data.update({k: children})
+        elif isinstance(rel, (AppenderMixin, Query)):
+            children = []
+            for child in rel.all():
+                if hasattr(child, 'asdict'):
+                    children.append(child.asdict(**args))
+                else:
+                    children.append(dict(child))
             data.update({k: children})
         else:
             raise errors.UnsupportedRelationError(k)


### PR DESCRIPTION
Attempts to fix issue, in which dynamically loaded SQLAlchemy relationship cause an exception because they are not properly converted to dictionaries.
Example:

``` python
class OfferPicture(db.Model):
    __tablename__ = 'offer_pictures'

    offer_id = db.Column(db.Integer, db.ForeignKey('offers.id'), nullable=False)
    url = db.Column(db.UnicodeText)

class Offer(db.Model):
    __tablename__ = 'offers'

    name = db.Column(db.Unicode(), nullable=False)
    pictures = db.relationship('OfferPicture', primaryjoin="OfferPicture.offer_id==Offer.id", backref=db.backref('offer'), lazy='dynamic')
```
