### PR TITLE
Allow serialization of empty relations

### DIFF
--- a/dictalchemy/utils.py
+++ b/dictalchemy/utils.py
@@ -155,6 +155,8 @@ def asdict(model, exclude=None, exclude_underscore=None, exclude_pk=None,
                 else:
                     children.append(dict(child))
             data.update({k: children})
+        elif rel is None:
+            data.update({k: None})
         else:
             raise errors.UnsupportedRelationError(k)
 


### PR DESCRIPTION
When foreign keys are set as nullable (i.e. they're optional) dictalchemy raises an exception when the relation is NULL. This commit attempts to fix this by detecting when the relationship is empty and then returning None.

For example, with the following models:

``` python
class Parent(db.Model):
    id = db.Column(db.Integer, primary_key=True)
    name = db.Column(db.Unicode(255), nullable=False)
    child_id = db.Column(db.Integer, db.ForeignKey('child.id'), nullable=True)
    child = db.relationship('Child', uselist=False)

class Child(db.Model):
    id = db.Column(db.Integer, primary_key=True)
    name = db.Column(db.Unicode(255), nullable=False)
```

Serializing an instance of Parent with no Child set should now succeed (with "child" as null), instead of raising an UnsupportedRelationError exception.
