### PR TITLE
Bring the project back to life

### DIFF
--- a/dictalchemy/__init__.py
+++ b/dictalchemy/__init__.py
@@ -6,7 +6,7 @@ Dictalchemy
 ~~~~~~~~~~~
 
 """
-from __future__ import absolute_import, division
+
 
 from dictalchemy.classes import DictableModel
 from dictalchemy.utils import make_class_dictable, asdict

--- a/dictalchemy/classes.py
+++ b/dictalchemy/classes.py
@@ -9,7 +9,7 @@ Contains :class:`DictableModel` that can be used as a base class for
 
 """
 
-from __future__ import absolute_import, division
+
 
 from dictalchemy import utils
 

--- a/dictalchemy/constants.py
+++ b/dictalchemy/constants.py
@@ -5,7 +5,7 @@ Constants
 ~~~~~~~~~
 
 """
-from __future__ import absolute_import, division
+
 
 default_exclude = None
 """Default value for asdict_exclude"""

--- a/dictalchemy/errors.py
+++ b/dictalchemy/errors.py
@@ -5,7 +5,7 @@ Errors
 ~~~~~~
 
 """
-from __future__ import absolute_import, division
+
 
 
 class DictalchemyError(Exception):

--- a/dictalchemy/tests/__init__.py
+++ b/dictalchemy/tests/__init__.py
@@ -1,5 +1,5 @@
 # vim: set fileencoding=utf-8 :
-from __future__ import absolute_import, division
+
 
 from dictalchemy import DictableModel
 from dictalchemy.utils import arg_to_dict
@@ -329,7 +329,7 @@ class AsHalMixin(object):
 
         follow = arg_to_dict(kwargs.get('follow', None))
         _embedded = {}
-        for (k, args) in follow.iteritems():
+        for (k, args) in follow.items():
             if args.get('_embedded', None) and k in result:
                 _embedded[k] = result.pop(k)
 

--- a/dictalchemy/tests/__init__.py
+++ b/dictalchemy/tests/__init__.py
@@ -225,7 +225,7 @@ class WithHybrid(Base):
         return self._value
 
     @value.setter
-    def set_value(self, value):
+    def value(self, value):
         self._value = value
 
     def __init__(self, value):
@@ -245,7 +245,7 @@ class WithDefaultInclude(Base):
         return self.id
 
     @id_alias.setter
-    def set_id_alias(self, value):
+    def id_alias(self, value):
         self.id = value
 
     def __init__(self, id):

--- a/dictalchemy/tests/test_asdict.py
+++ b/dictalchemy/tests/test_asdict.py
@@ -1,5 +1,5 @@
 # vim: set fileencoding=utf-8 :
-from __future__ import absolute_import, division
+
 from dictalchemy.tests import (
     TestCase,
     Named,

--- a/dictalchemy/tests/test_fromdict.py
+++ b/dictalchemy/tests/test_fromdict.py
@@ -1,5 +1,5 @@
 # vim: set fileencoding=utf-8 :
-from __future__ import absolute_import, division
+
 
 from dictalchemy import (
     DictalchemyError,
@@ -58,7 +58,7 @@ class TestFromdict(TestCase):
         try:
             named.fromdict(new)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert True, str(e)
 
     def test_one_to_many_plain(self):

--- a/dictalchemy/tests/test_utils.py
+++ b/dictalchemy/tests/test_utils.py
@@ -1,5 +1,5 @@
 # vim: set fileencoding=utf-8 :
-from __future__ import absolute_import, division
+
 
 import unittest
 import dictalchemy.tests as tests

--- a/dictalchemy/utils.py
+++ b/dictalchemy/utils.py
@@ -4,7 +4,7 @@
 Utilities
 ~~~~~~~~~
 """
-from __future__ import absolute_import, division
+
 
 import copy
 from sqlalchemy import inspect
@@ -117,7 +117,7 @@ def asdict(model, exclude=None, exclude_underscore=None, exclude_pk=None,
 
     data = dict([(k, getattr(model, k)) for k in attrs])
 
-    for (rel_key, orig_args) in follow.iteritems():
+    for (rel_key, orig_args) in follow.items():
 
         try:
             rel = getattr(model, rel_key)
@@ -147,7 +147,7 @@ def asdict(model, exclude=None, exclude_underscore=None, exclude_pk=None,
         elif isinstance(rel, dict):
             rel_data = {}
 
-            for (child_key, child) in rel.iteritems():
+            for (child_key, child) in rel.items():
                 if hasattr(child, method):
                     rel_data[child_key] = getattr(child, method)(**args)
                 else:
@@ -271,7 +271,7 @@ def fromdict(model, data, exclude=None, exclude_underscore=None,
         setattr(model, k, data[k])
 
     # Update simple relations
-    for (k, args) in follow.iteritems():
+    for (k, args) in follow.items():
         if k not in data:
             continue
         if k not in relations:
@@ -288,7 +288,7 @@ def iter(model):
 
     Yields everything returned by `asdict`.
     """
-    for i in model.asdict().iteritems():
+    for i in model.asdict().items():
         yield i
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,6 @@ install_requires = [
 # Requirement for running tests
 test_requires = install_requires
 
-extra = {}
-if sys.version_info >= (3,):
-    extra['use_2to3'] = True
-
 setup(name='dictalchemy',
       version='0.1.2.7',
       description="Contains asdict and fromdict methods for SQL-Alchemy "
@@ -53,5 +49,5 @@ setup(name='dictalchemy',
       zip_safe=False,
       install_requires=install_requires,
       tests_require=test_requires,
-      test_suite='dictalchemy',
-      **extra)
+      test_suite='dictalchemy')
+


### PR DESCRIPTION
SQLAlchemy has restricted the naming of hybrid methods and attributes since a while ago, not sure exactly when. Also, I considered it to be reasonable to make the 2to3 permanent. This pull request refreshes dictalchemy to work with the currently latest versions of its dependencies both with Python 2.7.17 and Python 3.8.6.

Tested with:
* Python 2.7.17 and SQLAlchemy-1.3.19-py2.7-linux-x86_64
* Python 3.8.6 and SQLAlchemy-1.3.19-py3.8-linux-x86_64
